### PR TITLE
[SC-111] dummy values for global.properties

### DIFF
--- a/src/main/resources/global.properties
+++ b/src/main/resources/global.properties
@@ -1,5 +1,5 @@
-SYNAPSE_OAUTH_CLIENT_ID=100053
-TEAM_TO_ROLE_ARN_MAP=[{"teamId":"273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]
+SYNAPSE_OAUTH_CLIENT_ID=111111
+TEAM_TO_ROLE_ARN_MAP=[{"teamId":"111111","roleArn":"arn:aws:iam::111111111111:role/ServiceCatalogEndusers"}]
 AWS_REGION=us-east-1
 SESSION_TIMEOUT_SECONDS=28800
 USER_CLAIMS=userid


### PR DESCRIPTION
We really don't need global.properties anymore because we are
using scipooldev.properties and scipoolprod.properties. We keep it
around only because tests are loading it by default.  We set
it's configuration to dummy values.