### PR TITLE
[SC-84] get oauth secret from the AWS SSM

### DIFF
--- a/src/main/resources/scipooldev.properties
+++ b/src/main/resources/scipooldev.properties
@@ -1,4 +1,9 @@
 SYNAPSE_OAUTH_CLIENT_ID=100055
+SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/synapse-login-scipooldev/SynapseOauthClientSecret
+AWS_REGION=us-east-1
+SESSION_TIMEOUT_SECONDS=28800
+USER_CLAIMS=userid
+
 # Synapse team mapping:
 # 3407239 scipool-admin
 # 3409012 scipooldev-internal
@@ -6,7 +11,3 @@ SYNAPSE_OAUTH_CLIENT_ID=100055
 TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409012","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409013","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}]
-AWS_REGION=us-east-1
-SESSION_TIMEOUT_SECONDS=28800
-USER_CLAIMS=userid
-

--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -1,4 +1,9 @@
 SYNAPSE_OAUTH_CLIENT_ID=100053
+SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/synapse-login-scipoolprod/SynapseOauthClientSecret
+AWS_REGION=us-east-1
+SESSION_TIMEOUT_SECONDS=28800
+USER_CLAIMS=userid
+
 # Synapse team mapping
 # 3407239 scipool-admin
 # 0273957 Sage Bionetworks
@@ -8,7 +13,3 @@ TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::465877038949:r
                       {"teamId":"0273957","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409010","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409011","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}]
-AWS_REGION=us-east-1
-SESSION_TIMEOUT_SECONDS=28800
-USER_CLAIMS=userid
-


### PR DESCRIPTION
Setup login app to retrieve SYNAPSE_OAUTH_CLIENT_SECRET directly
from the AWS SSM instead of from an environment variable.