### PR TITLE
Team IDs are strings, not numbers so you can't, for example, add lead…

### DIFF
--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -7,10 +7,10 @@ SESSION_TAG_CLAIMS=sub,userid,user_name,team,company,given_name,family_name
 
 # Synapse team mapping
 # 3407239 scipool-admin
-# 0273957 Sage Bionetworks
+#  273957 Sage Bionetworks
 # 3409010 scipoolprod-internal
 # 3409011 scipoolprod-external
 TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
-                      {"teamId":"0273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
+                      {"teamId": "273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]


### PR DESCRIPTION
Team IDs are strings, not numbers so you can't, for example, add leading zeros