### PR TITLE
SC-176

### DIFF
--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -348,11 +348,12 @@ public class Auth extends HttpServlet {
 				}});
 			
 			resp.setHeader("Location", redirectURL);
-			resp.setStatus(302);
+			resp.setStatus(303);
 		}	else if (uri.equals(HEALTH_URI)) {
 			resp.setStatus(200);
 		} else {
-			throw new RuntimeException("Unexpected URI "+req.getRequestURI());
+			resp.setHeader("Location", "");
+			resp.setStatus(303);
 		}
 	}
 	

--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -7,10 +7,10 @@ SESSION_TAG_CLAIMS=sub,userid,user_name,team,company,given_name,family_name
 
 # Synapse team mapping
 # 3407239 scipool-admin
-# 0273957 Sage Bionetworks
+#  273957 Sage Bionetworks
 # 3409010 scipoolprod-internal
 # 3409011 scipoolprod-external
 TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
-                      {"teamId":"0273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
+                      {"teamId": "273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}]


### PR DESCRIPTION
Changed the behavior for illegal URLs, as discussed in SC-176:
Previously, going to https://sc.sageit.org/some-bad-string would cause an exception. This change will cause a redirect back to https://sc.sageit.org.    

Also, in the redirect to the AWS console, the application currently uses a 302 redirect, but this status has been superseded by 303, 307.  https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_Redirection This PR changes from 302 to 303 to be up-to-date and to be clear that the client should perform a GET at the new URL.