### PR TITLE
SC-176

### DIFF
--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -352,7 +352,7 @@ public class Auth extends HttpServlet {
 		}	else if (uri.equals(HEALTH_URI)) {
 			resp.setStatus(200);
 		} else {
-			resp.setHeader("Location", "");
+			resp.setHeader("Location", getThisEndpoint(req));
 			resp.setStatus(303);
 		}
 	}


### PR DESCRIPTION
When redirecting for wrong URI, give an absolute URL in the Location header
