### PR TITLE
SC-178 skip adding team tag to session tags

### DIFF
--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -265,6 +265,7 @@ public class Auth extends HttpServlet {
 			}
 		}
 		sessionTags.put(TAG_PREFIX+TEAM_CLAIM_NAME, selectedTeam);
+		sessionTags.remove(TAG_PREFIX+TEAM_CLAIM_NAME); // temporary, to test the effect of the team tag on SC-178
 		
 		StringBuilder awsSessionName = new StringBuilder();
 		boolean first=true;
@@ -283,7 +284,7 @@ public class Auth extends HttpServlet {
 		for (String tagName: sessionTags.keySet()) {
 			tags.add(new Tag().withKey(tagName).withValue(sessionTags.get(tagName)));				
 		}
-		// assumeRoleRequest.setTags(tags); This is a temporary change to see if it solves SC-178
+		assumeRoleRequest.setTags(tags);
 		return assumeRoleRequest;
 	}
 		

--- a/src/test/java/synapseawsconsolelogin/AuthTest.java
+++ b/src/test/java/synapseawsconsolelogin/AuthTest.java
@@ -223,11 +223,11 @@ public class AuthTest {
 		assertEquals(roleArn, request.getRoleArn());
 		assertEquals("1:aname", request.getRoleSessionName());
 		
-// temporarily disabled
-//		assertEquals(3, request.getTags().size());
-//		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-user_name").withValue("aname")));
-//		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-userid").withValue("1")));
-//		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-team").withValue("10101")));
+		//assertEquals(3, request.getTags().size()); // temporary change for SC-178 
+		assertEquals(2, request.getTags().size()); // temporary change for SC-178
+		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-user_name").withValue("aname")));
+		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-userid").withValue("1")));
+		//assertTrue(request.getTags().contains((new Tag()).withKey("synapse-team").withValue("10101")));// temporary change for SC-178 
 		
 	}
 


### PR DESCRIPTION
skip adding team tag to session tags -- an experiment as part of investigating SC-178, to be deployed in the dev' environment only.