### PR TITLE
Revert "Revert "[SC-206] Use the shared key (#41)""

### DIFF
--- a/src/main/resources/scipooldev.properties
+++ b/src/main/resources/scipooldev.properties
@@ -1,5 +1,5 @@
 SYNAPSE_OAUTH_CLIENT_ID=100055
-SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/synapse-login-scipooldev/SynapseOauthClientSecret
+SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
 AWS_REGION=us-east-1
 SESSION_TIMEOUT_SECONDS=28800
 SESSION_NAME_CLAIMS=userid

--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -1,5 +1,5 @@
 SYNAPSE_OAUTH_CLIENT_ID=100053
-SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/synapse-login-scipoolprod/SynapseOauthClientSecret
+SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
 AWS_REGION=us-east-1
 SESSION_TIMEOUT_SECONDS=28800
 SESSION_NAME_CLAIMS=userid


### PR DESCRIPTION
This reverts commit 9a606e4a58ac0c999e9d18518648b4884caf4946.
Renable login app to use the new shared key.

depends on https://github.com/Sage-Bionetworks/synapse-login-aws-infra/pull/36