### PR TITLE
Add Synapse groups to properties

### DIFF
--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -10,8 +10,12 @@ REDIRECT_URIS=https://synapse-login-scipoolprod.scipoolprod.org/synapse,https://
 # 3407239 scipool-admin
 #  273957 Sage Bionetworks
 # 3409010 scipoolprod-internal
+# 3412678 ampad-workinggroup
+# 3412679 ampad-portalusers
 # 3409011 scipoolprod-external
 TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId": "273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
                       {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
+		      {"teamId": "3412678","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}, \
+		      {"teamId": "3412679","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}, \
                       {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}]


### PR DESCRIPTION
The Synapse teams `ampad-workinggroup` and `ampad-portalusers` map to the `ServiceCatalogExternalEndusers` role in this change.