### PR TITLE
[SC-207] reference app configs in the parameter store

### DIFF
--- a/src/main/resources/scipooldev.properties
+++ b/src/main/resources/scipooldev.properties
@@ -1,15 +1,8 @@
-SYNAPSE_OAUTH_CLIENT_ID=100055
+SYNAPSE_OAUTH_CLIENT_ID=ssm::/service-catalog/SynapseOauthClientId
 SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
-AWS_REGION=us-east-1
-SESSION_TIMEOUT_SECONDS=28800
-SESSION_NAME_CLAIMS=userid
-SESSION_TAG_CLAIMS=sub,userid,team,user_name,company,given_name,family_name
-REDIRECT_URIS=https://synapse-login-scipooldev.scipooldev.org/synapse,https://connect.scipooldev.org/oauth2/idpresponse
-
-# Synapse team mapping:
-# 3407239 scipool-admin
-# 3409012 scipooldev-internal
-# 3409013 scipooldev-external
-TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
-                      {"teamId":"3409012","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogEndusers"}, \
-                      {"teamId":"3409013","roleArn":"arn:aws:iam::465877038949:role/ServiceCatalogExternalEndusers"}]
+AWS_REGION=ssm::/service-catalog/AwsRegion
+SESSION_TIMEOUT_SECONDS=ssm::/service-catalog/SessionTimeoutSeconds
+SESSION_NAME_CLAIMS=ssm::/service-catalog/SessionNameClaims
+SESSION_TAG_CLAIMS=ssm::/service-catalog/SessionTagClaims
+REDIRECT_URIS=ssm::/service-catalog/RedirectUris
+TEAM_TO_ROLE_ARN_MAP=ssm::/service-catalog/TeamToRoleArnMap

--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -1,21 +1,8 @@
-SYNAPSE_OAUTH_CLIENT_ID=100053
+SYNAPSE_OAUTH_CLIENT_ID=ssm::/service-catalog/SynapseOauthClientId
 SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
-AWS_REGION=us-east-1
-SESSION_TIMEOUT_SECONDS=28800
-SESSION_NAME_CLAIMS=userid
-SESSION_TAG_CLAIMS=sub,userid,team,user_name,company,given_name,family_name
-REDIRECT_URIS=https://synapse-login-scipoolprod.scipoolprod.org/synapse,https://connect.scipoolprod.org/oauth2/idpresponse 
-
-# Synapse team mapping
-# 3407239 scipool-admin
-#  273957 Sage Bionetworks
-# 3409010 scipoolprod-internal
-# 3412678 ampad-workinggroup
-# 3412679 ampad-portalusers
-# 3409011 scipoolprod-external
-TEAM_TO_ROLE_ARN_MAP=[{"teamId":"3407239","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
-                      {"teamId": "273957","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
-                      {"teamId":"3409010","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogEndusers"}, \
-		      {"teamId": "3412678","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}, \
-		      {"teamId": "3412679","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}, \
-                      {"teamId":"3409011","roleArn":"arn:aws:iam::237179673806:role/ServiceCatalogExternalEndusers"}]
+AWS_REGION=ssm::/service-catalog/AwsRegion
+SESSION_TIMEOUT_SECONDS=ssm::/service-catalog/SessionTimeoutSeconds
+SESSION_NAME_CLAIMS=ssm::/service-catalog/SessionNameClaims
+SESSION_TAG_CLAIMS=ssm::/service-catalog/SessionTagClaims
+REDIRECT_URIS=ssm::/service-catalog/RedirectUris
+TEAM_TO_ROLE_ARN_MAP=ssm::/service-catalog/TeamToRoleArnMap


### PR DESCRIPTION
App configurations have been added to the SSM parameter store now
we can reference configs from new location

depends on Sage-Bionetworks/synapse-login-aws-infra#38