### PR TITLE
[SC-207] remove configuration files

### DIFF
--- a/src/main/resources/scipooldev.properties
+++ b/src/main/resources/scipooldev.properties
@@ -1,8 +1,0 @@
-SYNAPSE_OAUTH_CLIENT_ID=ssm::/service-catalog/SynapseOauthClientId
-SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
-AWS_REGION=ssm::/service-catalog/AwsRegion
-SESSION_TIMEOUT_SECONDS=ssm::/service-catalog/SessionTimeoutSeconds
-SESSION_NAME_CLAIMS=ssm::/service-catalog/SessionNameClaims
-SESSION_TAG_CLAIMS=ssm::/service-catalog/SessionTagClaims
-REDIRECT_URIS=ssm::/service-catalog/RedirectUris
-TEAM_TO_ROLE_ARN_MAP=ssm::/service-catalog/TeamToRoleArnMap

--- a/src/main/resources/scipoolprod.properties
+++ b/src/main/resources/scipoolprod.properties
@@ -1,8 +1,0 @@
-SYNAPSE_OAUTH_CLIENT_ID=ssm::/service-catalog/SynapseOauthClientId
-SYNAPSE_OAUTH_CLIENT_SECRET=ssm::/service-catalog/SynapseOauthClientSecret
-AWS_REGION=ssm::/service-catalog/AwsRegion
-SESSION_TIMEOUT_SECONDS=ssm::/service-catalog/SessionTimeoutSeconds
-SESSION_NAME_CLAIMS=ssm::/service-catalog/SessionNameClaims
-SESSION_TAG_CLAIMS=ssm::/service-catalog/SessionTagClaims
-REDIRECT_URIS=ssm::/service-catalog/RedirectUris
-TEAM_TO_ROLE_ARN_MAP=ssm::/service-catalog/TeamToRoleArnMap


### PR DESCRIPTION
Application configurations are now being loaded by beanstalk ENV vars
therefore we no longer need to package app config vars with the app.

depends on Sage-Bionetworks/synapse-login-aws-infra#43