### PR TITLE
SC-254 make dynamo column name match that used in scipool-infra

### DIFF
--- a/src/main/java/synapseawsconsolelogin/DynamoDbHelper.java
+++ b/src/main/java/synapseawsconsolelogin/DynamoDbHelper.java
@@ -1,7 +1,6 @@
 package synapseawsconsolelogin;
 
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -17,9 +16,9 @@ import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 
 public class DynamoDbHelper {
 	
-	private static final String USER_ID = "userId";
-	private static final String PRODUCT_CODE = "productCode";
-	private static final String CUSTOMER_ID = "marketplaceCustomerId";
+	private static final String USER_ID = "SynapseUserId";
+	private static final String PRODUCT_CODE = "ProductCode";
+	private static final String CUSTOMER_ID = "MarketplaceCustomerId";
 	
 	private AmazonDynamoDB amazonDynamoDB;
 	

--- a/src/test/java/synapseawsconsolelogin/DynamoDbHelperTest.java
+++ b/src/test/java/synapseawsconsolelogin/DynamoDbHelperTest.java
@@ -62,9 +62,9 @@ public class DynamoDbHelperTest {
 		
 		Map<String, AttributeValue> itemToAdd = putItemRequestCaptor.getValue().getItem();
 		
-		assertEquals(userId, itemToAdd.get("userId").getS());
-		assertEquals(productCode, itemToAdd.get("productCode").getS());
-		assertEquals(customerIdentifier, itemToAdd.get("marketplaceCustomerId").getS());
+		assertEquals(userId, itemToAdd.get("SynapseUserId").getS());
+		assertEquals(productCode, itemToAdd.get("ProductCode").getS());
+		assertEquals(customerIdentifier, itemToAdd.get("MarketplaceCustomerId").getS());
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class DynamoDbHelperTest {
 		
 		GetItemResult getItemResult = new GetItemResult();
 		AttributeValue attributeValue = new AttributeValue().withS(customerId);
-		getItemResult.addItemEntry("marketplaceCustomerId", attributeValue);
+		getItemResult.addItemEntry("MarketplaceCustomerId", attributeValue);
 		when(mockAmazonDynamoDB.getItem((GetItemRequest)any())).thenReturn(getItemResult);
 
 		// method under test
@@ -86,9 +86,9 @@ public class DynamoDbHelperTest {
 		GetItemRequest getItemRequest = getItemRequestCaptor.getValue();
 		
 		assertEquals(TABLE_NAME, getItemRequest.getTableName());
-		assertEquals(userId, getItemRequest.getKey().get("userId").getS());
+		assertEquals(userId, getItemRequest.getKey().get("SynapseUserId").getS());
 		
-		List<String> expectedAttributes = Arrays.asList(new String[] {"productCode", "marketplaceCustomerId"});
+		List<String> expectedAttributes = Arrays.asList(new String[] {"ProductCode", "MarketplaceCustomerId"});
 		assertEquals(expectedAttributes, getItemRequest.getAttributesToGet());
 		assertTrue(getItemRequest.getConsistentRead());
 		
@@ -112,9 +112,9 @@ public class DynamoDbHelperTest {
 		GetItemRequest getItemRequest = getItemRequestCaptor.getValue();
 		
 		assertEquals(TABLE_NAME, getItemRequest.getTableName());
-		assertEquals(userId, getItemRequest.getKey().get("userId").getS());
+		assertEquals(userId, getItemRequest.getKey().get("SynapseUserId").getS());
 		
-		List<String> expectedAttributes = Arrays.asList(new String[] {"productCode", "marketplaceCustomerId"});
+		List<String> expectedAttributes = Arrays.asList(new String[] {"ProductCode", "MarketplaceCustomerId"});
 		assertEquals(expectedAttributes, getItemRequest.getAttributesToGet());
 		assertTrue(getItemRequest.getConsistentRead());
 		


### PR DESCRIPTION
This code used “userId” while scipool-infra uses “SynapseUserId”.  With this PR, this code uses SynapseUserId and to make the other DynamoDB fields match, they are changed as shown.
