### PR TITLE
SC-254  marketplace token is a *parameter* not a *header*

### DIFF
--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -47,9 +47,6 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.regions.Regions;
-import com.amazonaws.services.marketplacemetering.AWSMarketplaceMetering;
-import com.amazonaws.services.marketplacemetering.AWSMarketplaceMeteringClientBuilder;
-import com.amazonaws.services.marketplacemetering.model.ResolveCustomerRequest;
 import com.amazonaws.services.marketplacemetering.model.ResolveCustomerResult;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
@@ -233,9 +230,9 @@ public class Auth extends HttpServlet {
 	 * as a Marketplace product.  Passes the temporary 'marketplace token' as the OAuth state parameter.
 	 */
 	public void handleSubscribe(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-		String awsMarketPlaceToken = req.getHeader("x-amzn-marketplace-token");
+		String awsMarketPlaceToken = req.getParameter("x-amzn-marketplace-token");
 		if (StringUtils.isEmpty(awsMarketPlaceToken)) {
-			String errorMessage = "Missing x-amzn-marketplace-token header";
+			String errorMessage = "Cannot continue subscription: Missing x-amzn-marketplace-token parameter.";
 			logger.log(Level.SEVERE, errorMessage);
 			resp.setContentType("text/plain");
 			try (ServletOutputStream os=resp.getOutputStream()) {

--- a/src/test/java/synapseawsconsolelogin/AuthTest.java
+++ b/src/test/java/synapseawsconsolelogin/AuthTest.java
@@ -145,7 +145,7 @@ public class AuthTest {
 		sb.append(baseUrl);
 		when(mockServletRequest.getRequestURL()).thenReturn(sb);
 		when(mockServletRequest.getRequestURI()).thenReturn(baseUrl);
-		when(mockServletRequest.getHeader("x-amzn-marketplace-token")).thenReturn(marketplaceToken);
+		when(mockServletRequest.getParameter("x-amzn-marketplace-token")).thenReturn(marketplaceToken);
 		
 		// method under test
 		auth.handleSubscribe(mockServletRequest, mockServletResponse);
@@ -165,7 +165,7 @@ public class AuthTest {
 		auth.handleSubscribe(mockServletRequest, mockServletResponse);
 		
 		verify(mockServletResponse).setStatus(400);
-		verify(mockServletOutputStream).println("Missing x-amzn-marketplace-token header");
+		verify(mockServletOutputStream).println("Cannot continue subscription: Missing x-amzn-marketplace-token parameter.");
 	}
 	
 	@Test


### PR DESCRIPTION
As explained in 
https://aws.amazon.com/blogs/apn/how-to-integrate-your-saas-service-with-saas-subscriptions-for-aws-marketplace/
x-amzn-marketplace-token is a request parameter.  I had mistakenly thought it was a request *header*.
