### PR TITLE
fix python on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - pyenv install --force 3.7.1
+#  - pyenv install --force 3.7.1
   - pyenv global 3.7.1
 install:
   - pip install pre-commit travis-wait-improved awsebcli

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - pyenv install 3.7.10
-  - pyenv global 3.7.10
+  - pyenv install 3.7.1
+  - pyenv global 3.7.1
 install:
   - pip install pre-commit travis-wait-improved awsebcli
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-  - pyenv install 3.7.1
+  - pyenv install --force 3.7.1
   - pyenv global 3.7.1
 install:
   - pip install pre-commit travis-wait-improved awsebcli

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   directories:
   - $HOME/.m2
 before_install:
-#  - pyenv install --force 3.7.1
   - pyenv global 3.7.1
   - pip install --upgrade pip
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 before_install:
 #  - pyenv install --force 3.7.1
   - pyenv global 3.7.1
+  - pip install --upgrade pip
 install:
   - pip install pre-commit travis-wait-improved awsebcli
 stages:


### PR DESCRIPTION
The travis ci ubuntu instance that was running the build changed somehow.
The python version that was used on it failed to run.  We switch to a version
that works.