### PR TITLE
update Synapse Client dependency in order to update log4j dependency to 2.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
   - $HOME/.m2
 before_install:
   - pyenv global 3.7.1
-  - pip install --upgrade pip
+  - pip3 install --upgrade pip
 install:
-  - pip install pre-commit travis-wait-improved awsebcli
+  - pip3 install pre-commit travis-wait-improved awsebcli
 stages:
   - name: test
   - name: deploy-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
   - $HOME/.m2
 before_install:
   - pyenv global 3.7.1
-  - pip3 install --upgrade pip
+  - pip install --upgrade pip
 install:
-  - pip3 install pre-commit travis-wait-improved awsebcli
+  - pip install pre-commit travis-wait-improved awsebcli
 stages:
   - name: test
   - name: deploy-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - pyenv global 3.7.1
   - pip install --upgrade pip
 install:
-  - pip install pre-commit travis-wait-improved awsebcli
+  - pip install pre-commit travis-wait-improved awsebcli~=3.19
 stages:
   - name: test
   - name: deploy-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - pyenv global 3.7.1
   - pip install --upgrade pip
 install:
-  - pip install pre-commit travis-wait-improved awsebcli~=3.19
+  - pip install pre-commit travis-wait-improved awsebcli
 stages:
   - name: test
   - name: deploy-develop

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<synapseVersion>361.0</synapseVersion>
+		<synapseVersion>386.0-5-g21f7882</synapseVersion>
+		<log4j.version>2.15.0</log4j.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<synapseVersion>386.0-5-g21f7882</synapseVersion>
-		<log4j.version>2.15.0</log4j.version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
update Synapse Client dependency in order to update log4j dependency to 2.15.0

Details: https://sagebionetworks.jira.com/browse/SC-377