### PR TITLE
SC-377: Update Synapse dependency to transitively update log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<synapseVersion>388.0</synapseVersion>
+		<synapseVersion>446.0</synapseVersion>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
SC-377
This is a follow-up to the update of the log4j dependency.  Aaron Hayden suggested that updating to log4j version 2.15 might not be sufficient, that we should update to 2.17. (See the Jira discussion.). We can do this by updating the Synapse dependency to the current version (446) which uses log4j version 2.17.
