### PR TITLE
fix eb deploy action

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -38,7 +38,6 @@ jobs:
           role-to-assume: ${{ inputs.role-to-assume }}
           role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
-      - name: Deploy
-        uses: hmanzur/actions-aws-eb@v1.0.0
-        with:
-          command:  ${{ inputs.ebcli-command }}
+      - uses: sparkplug-app/install-eb-cli-action
+      - name: Deploy to Beanstalk
+        run: ${{ inputs.ebcli-command }}

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -39,5 +39,7 @@ jobs:
           role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
       - uses: sparkplug-app/install-eb-cli-action
+        with:
+          version: 3.19.4
       - name: Deploy to Beanstalk
         run: ${{ inputs.ebcli-command }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,25 +24,25 @@ jobs:
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::465877038949:role/sagebase-github-oidc-scipool-dev-synapse-login-aws-infra"
-      ebcli-command: "deploy --verbose --staged --timeout 30 synapse-login-scipooldev"
+      ebcli-command: "eb deploy --verbose --staged --timeout 30m synapse-login-scipooldev"
   deploy-scipoolprod:
     if: github.ref == 'refs/heads/prod'
     needs: [test]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::237179673806:role/sagebase-github-oidc-scipool-prod-synapse-login-aws-infra"
-      ebcli-command: "deploy --verbose --staged --timeout 30 synapse-login-scipoolprod"
+      ebcli-command: "eb deploy --verbose --staged --timeout 30m synapse-login-scipoolprod"
   deploy-bmgfki:
     if: github.ref == 'refs/heads/prod'
     needs: [test]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::464102568320:role/sagebase-github-oidc-scipool-prod-synapse-login-aws-infra"
-      ebcli-command: "deploy --verbose --staged --timeout 30 synapse-login-bmgfki"
+      ebcli-command: "eb deploy --verbose --staged --timeout 30m synapse-login-bmgfki"
   deploy-strides:
     if: github.ref == 'refs/heads/prod'
     needs: [test]
     uses: "./.github/workflows/aws-deploy.yaml"
     with:
       role-to-assume: "arn:aws:iam::423819316185:role/github-oidc-sage-bionetworks"
-      ebcli-command: "deploy --verbose --staged --timeout 30 synapse-login-strides"
+      ebcli-command: "eb deploy --verbose --staged --timeout 30m synapse-login-strides"


### PR DESCRIPTION
The `hmanzur/actions-aws-eb@v1.0.0` failed to install EB CLI. The repo[1] has fixes however the maintainer does not seem very active.  We try a different action to see if we can get this app deployed to beanstalk.

[1] https://github.com/hmanzur/actions-aws-eb

