### PR TITLE
fix eb cli

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -39,7 +39,13 @@ jobs:
           role-to-assume: ${{ inputs.role-to-assume }}
           role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
-      - uses: sparkplug-app/install-eb-cli-action@v1.1.1
+      # install specific version of python and EBCLI as a workaround for https://github.com/aws/aws-elastic-beanstalk-cli-setup/issues/148
+      - name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Install EB CLI
+        uses: sparkplug-app/install-eb-cli-action@v1.1.1
         with:
           version: 3.19.4
       - name: Deploy to Beanstalk


### PR DESCRIPTION
running elastic beanstalk CLI with python 3.11 fails with the following error..

```
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/ebcli/core/ebrun.py", line 62, in run_app
    app.run()
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/cement/core/foundation.py", line 797, in run
    return_val = self.controller._dispatch()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/cement/core/controller.py", line 472, in _dispatch
    return func()
           ^^^^^^
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/cement/core/controller.py", line 478, in _dispatch
    return func()
           ^^^^^^
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/ebcli/core/abstractcontroller.py", line 92, in default
    self.do_command()
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/ebcli/controllers/deploy.py", line 79, in do_command
    deployops.deploy(self.app_name, self.env_name, self.version, self.label,
  File "/home/runner/.ebcli-virtual-env/lib/python3.11/site-packages/ebcli/operations/deployops.py", line 32, in deploy
    io.log_info('Deploying code to ' + env_name + " in region " + region_name)
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
TypeError: can only concatenate str (not "NoneType") to str
```

attempt to fix by running ebcli with python 3.8

