### PR TITLE
Fix EB CLI install

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -39,6 +39,9 @@ jobs:
           role-to-assume: ${{ inputs.role-to-assume }}
           role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ inputs.role-duration-seconds }}
-      - uses: sparkplug-app/install-eb-cli-action@v1.1.1
+      # Install EB CLI from pypi instead of https://github.com/aws/aws-elastic-beanstalk-cli-setup
+      # due to issue https://github.com/aws/aws-elastic-beanstalk-cli-setup/issues/148
+      - name: Install EB CLI
+        run: pip install PyYAML==5.3.1 awsebcli
       - name: Deploy to Beanstalk
         run: ${{ inputs.ebcli-command }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn clean package
+
+  # Deploy with EB CLI using work around https://stackoverflow.com/a/53364728
   deploy-scipooldev:
     if: github.ref == 'refs/heads/develop'
     needs: [test]


### PR DESCRIPTION
Installation of EB CLI failed, we try to switch to installing from pypi with the workaround suggestion from
https://github.com/aws/aws-elastic-beanstalk-cli-setup/issues/148#issuecomment-1647061226

