### PR TITLE
[IT-4462] Update org.sagebionetworks:synapseJavaClient library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<synapseVersion>446.0</synapseVersion>
+		<synapseVersion>561.0-2-gb05e6ab884</synapseVersion>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Version 446.0 is no longer in sage jfrog[1] or the maven central repo[2].

@xschildw recommended updating to the current prod version

[1] https://sagebionetworks.jfrog.io/ui/native/libs-releases-local/org/sagebionetworks/synapseJavaClient/
[2] https://mvnrepository.com/artifact/org.sagebionetworks/synapseJavaClient

