### PR TITLE
[IT-4462] update aws-java-sdk library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 		    <groupId>com.amazonaws</groupId>
 		    <artifactId>aws-java-sdk</artifactId>
-		    <version>1.11.774</version>
+		    <version>1.12.772</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
There is a v2.x however migrating to 2.x would be a major change and would require a lot of refactoring. Java 11 supports v1.x so we stay on this version.

Note: AWS SDK v1 entered maintenance mode in July 2024 and will reach end-of-support on December 31, 2025[1]

[1] https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/
