### PR TITLE
[IT-4462] upgrade AWS Java SDK from version 1 to version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ hs_err_pid*
 .idea/
 *.iml
 
+# VSCode
+.vscode/
+
 # maven
 target/
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ hs_err_pid*
 .idea/
 *.iml
 
-# VSCode
-.vscode/
-
 # maven
 target/
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,17 @@
 	
 	<dependencies>
 	
-		<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
+		<!-- AWS SDK v2 dependencies -->
 		<dependency>
-		    <groupId>com.amazonaws</groupId>
-		    <artifactId>aws-java-sdk</artifactId>
-		    <version>1.12.772</version>
+		    <groupId>software.amazon.awssdk</groupId>
+		    <artifactId>sts</artifactId>
+		    <version>2.29.16</version>
+		</dependency>
+		
+		<dependency>
+		    <groupId>software.amazon.awssdk</groupId>
+		    <artifactId>ssm</artifactId>
+		    <version>2.29.16</version>
 		</dependency>
 		
 		<dependency>

--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -54,20 +54,17 @@ import org.sagebionetworks.repo.model.oauth.OIDCClaimsRequestDetails;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.Verifier;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
-import com.amazonaws.services.securitytoken.model.Credentials;
-import com.amazonaws.services.securitytoken.model.Tag;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.Tag;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
@@ -192,7 +189,7 @@ public class Auth extends HttpServlet {
 	private Properties ssmParameterCache = null;
 	private String awsConsoleUrl;
 	private String appVersion = null;
-	private AWSSecurityTokenService stsClient = null;
+	private StsClient stsClient = null;
 	private HttpGetExecutor httpGetExecutor	= null;
 	private TokenRetriever tokenRetriever = null;
 	private JWTClaimsExtractor jwtClaimsExtractor = null;
@@ -214,7 +211,7 @@ public class Auth extends HttpServlet {
 		return result;
 	}
 
-	private void init(AWSSecurityTokenService stsClient, 
+	private void init(StsClient stsClient, 
 			HttpGetExecutor httpGetExecutor, 
 			TokenRetriever tokenRetriever,
 			JWTClaimsExtractor jwtClaimsExtractor,
@@ -241,7 +238,7 @@ public class Auth extends HttpServlet {
 	/*
 	 * For testing
 	 */
-	public Auth(AWSSecurityTokenService stsClient, 
+	public Auth(StsClient stsClient, 
 			HttpGetExecutor httpGetExecutor, 
 			TokenRetriever tokenRetriever,
 			JWTClaimsExtractor jwtClaimsExtractor,
@@ -253,8 +250,9 @@ public class Auth extends HttpServlet {
 	public Auth() {
 		initProperties();
 		String awsRegion = getProperty(AWS_REGION_PARAMETER);
-		AWSSecurityTokenService stsClient = AWSSecurityTokenServiceClientBuilder.standard()
-				.withRegion(Regions.fromName(awsRegion)).build();
+		StsClient stsClient = StsClient.builder()
+				.region(Region.of(awsRegion))
+				.build();
 		
 		HttpGetExecutor httpExecutor = new HttpGetExecutor() {
 			@Override
@@ -464,9 +462,9 @@ public class Auth extends HttpServlet {
 		// including the access key ID,  secret access key, and security token.
 		String sessionJson = String.format(
 		  "{\"%1$s\":\"%2$s\",\"%3$s\":\"%4$s\",\"%5$s\":\"%6$s\"}",
-		  "sessionId", federatedCredentials.getAccessKeyId(),
-		  "sessionKey", federatedCredentials.getSecretAccessKey(),
-		  "sessionToken", federatedCredentials.getSessionToken());
+		  "sessionId", federatedCredentials.accessKeyId(),
+		  "sessionKey", federatedCredentials.secretAccessKey(),
+		  "sessionToken", federatedCredentials.sessionToken());
 		              
 		// Construct the sign-in request with the request sign-in token action, a
 		// specified console session duration, and the JSON document with temporary 
@@ -541,15 +539,19 @@ public class Auth extends HttpServlet {
 		String awsSessionName = stringBuilder.toString();
 		
 		// get STS token
-		AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest();
-		assumeRoleRequest.setRoleArn(roleArn);
-		assumeRoleRequest.setRoleSessionName(awsSessionName);
 		Collection<Tag> tags = new ArrayList<Tag>();
 		for (String tagName: sessionTags.keySet()) {
-			tags.add(new Tag().withKey(tagName).withValue(sanitizeTagValue(sessionTags.get(tagName))));				
+			tags.add(Tag.builder()
+					.key(tagName)
+					.value(sanitizeTagValue(sessionTags.get(tagName)))
+					.build());				
 		}
-		assumeRoleRequest.setTags(tags);
-		return assumeRoleRequest;
+		
+		return AssumeRoleRequest.builder()
+				.roleArn(roleArn)
+				.roleSessionName(awsSessionName)
+				.tags(tags)
+				.build();
 	}
 	
 	/**
@@ -604,8 +606,8 @@ public class Auth extends HttpServlet {
 	void redirectToSCConsole(Map<String,Object> claims, String roleArn, String selectedTeam, HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		AssumeRoleRequest assumeRoleRequest = createAssumeRoleRequest(claims, roleArn, selectedTeam);
 		
-		AssumeRoleResult assumeRoleResult = stsClient.assumeRole(assumeRoleRequest);
-		Credentials credentials = assumeRoleResult.getCredentials();
+		AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
+		Credentials credentials = assumeRoleResponse.credentials();
 		// redirect to AWS login
 		String redirectURL = getConsoleLoginURL(req, credentials);
 		
@@ -634,13 +636,13 @@ public class Auth extends HttpServlet {
 	void returnStsToken(Map<String,Object> claims, String roleArn, String selectedTeam, HttpServletResponse resp) throws IOException {
 		AssumeRoleRequest assumeRoleRequest = createAssumeRoleRequest(claims, roleArn, selectedTeam);
 		
-		AssumeRoleResult assumeRoleResult = stsClient.assumeRole(assumeRoleRequest);
-		Credentials credentials = assumeRoleResult.getCredentials();
+		AssumeRoleResponse assumeRoleResponse = stsClient.assumeRole(assumeRoleRequest);
+		Credentials credentials = assumeRoleResponse.credentials();
 		Map<String,Object> sts = new HashMap<String,Object>();
-		sts.put("AccessKeyId", credentials.getAccessKeyId());
-		sts.put("SecretAccessKey", credentials.getSecretAccessKey());
-		sts.put("SessionToken", credentials.getSessionToken());
-		sts.put("Expiration", formatDateAsIso8601(credentials.getExpiration()));
+		sts.put("AccessKeyId", credentials.accessKeyId());
+		sts.put("SecretAccessKey", credentials.secretAccessKey());
+		sts.put("SessionToken", credentials.sessionToken());
+		sts.put("Expiration", formatDateAsIso8601(Date.from(credentials.expiration())));
 		sts.put("Version", 1);
 
 		writeFileToResponse(createSerializedJSON(sts), STS_TOKEN_FILE_NAME, resp);
@@ -928,19 +930,21 @@ public class Auth extends HttpServlet {
 			throw new IllegalArgumentException("SSM parameter name cannot be empty.");
 		}
 		try {
-			DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+			DefaultCredentialsProvider.create().resolveCredentials();
 		} catch (SdkClientException e) {
 			return null;
 		}
-		AWSSimpleSystemsManagement ssmClient = AWSSimpleSystemsManagementClientBuilder.defaultClient();
-		GetParameterRequest getParameterRequest = new GetParameterRequest();
-		getParameterRequest.setName(name);
-		getParameterRequest.setWithDecryption(true);
-		try {
-			GetParameterResult getParameterResult = ssmClient.getParameter(getParameterRequest);
-			return getParameterResult.getParameter().getValue();
-		} catch (AmazonClientException e) {
-			return null;
+		try (SsmClient ssmClient = SsmClient.builder().build()) {
+			GetParameterRequest getParameterRequest = GetParameterRequest.builder()
+					.name(name)
+					.withDecryption(true)
+					.build();
+			try {
+				GetParameterResponse getParameterResponse = ssmClient.getParameter(getParameterRequest);
+				return getParameterResponse.parameter().value();
+			} catch (SdkClientException e) {
+				return null;
+			}
 		}
 	}
 

--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -250,6 +250,7 @@ public class Auth extends HttpServlet {
 	public Auth() {
 		initProperties();
 		String awsRegion = getProperty(AWS_REGION_PARAMETER);
+		// Store the StsClient as a field so it can be properly closed
 		StsClient stsClient = StsClient.builder()
 				.region(Region.of(awsRegion))
 				.build();
@@ -929,8 +930,8 @@ public class Auth extends HttpServlet {
 		if (name.length()<1) {
 			throw new IllegalArgumentException("SSM parameter name cannot be empty.");
 		}
-		try {
-			DefaultCredentialsProvider.create().resolveCredentials();
+		try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
+			credentialsProvider.resolveCredentials();
 		} catch (SdkClientException e) {
 			return null;
 		}
@@ -959,6 +960,22 @@ public class Auth extends HttpServlet {
 
 	public String getAppVersion() {
 		return appVersion;
+	}
+
+	/**
+	 * Servlet destroy method to properly close AWS SDK clients and prevent resource leaks.
+	 * Called by the servlet container when the servlet is being taken out of service.
+	 */
+	@Override
+	public void destroy() {
+		if (stsClient != null) {
+			try {
+				stsClient.close();
+			} catch (Exception e) {
+				logger.log(Level.WARNING, "Error closing STS client", e);
+			}
+		}
+		super.destroy();
 	}
 
 }

--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -250,7 +250,6 @@ public class Auth extends HttpServlet {
 	public Auth() {
 		initProperties();
 		String awsRegion = getProperty(AWS_REGION_PARAMETER);
-		// Store the StsClient as a field so it can be properly closed
 		StsClient stsClient = StsClient.builder()
 				.region(Region.of(awsRegion))
 				.build();
@@ -930,8 +929,8 @@ public class Auth extends HttpServlet {
 		if (name.length()<1) {
 			throw new IllegalArgumentException("SSM parameter name cannot be empty.");
 		}
-		try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
-			credentialsProvider.resolveCredentials();
+		try {
+			DefaultCredentialsProvider.create().resolveCredentials();
 		} catch (SdkClientException e) {
 			return null;
 		}
@@ -960,22 +959,6 @@ public class Auth extends HttpServlet {
 
 	public String getAppVersion() {
 		return appVersion;
-	}
-
-	/**
-	 * Servlet destroy method to properly close AWS SDK clients and prevent resource leaks.
-	 * Called by the servlet container when the servlet is being taken out of service.
-	 */
-	@Override
-	public void destroy() {
-		if (stsClient != null) {
-			try {
-				stsClient.close();
-			} catch (Exception e) {
-				logger.log(Level.WARNING, "Error closing STS client", e);
-			}
-		}
-		super.destroy();
 	}
 
 }

--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -930,8 +930,8 @@ public class Auth extends HttpServlet {
 		if (name.length()<1) {
 			throw new IllegalArgumentException("SSM parameter name cannot be empty.");
 		}
-		try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
-			credentialsProvider.resolveCredentials();
+		try {
+			DefaultCredentialsProvider.create().resolveCredentials();
 		} catch (SdkClientException e) {
 			return null;
 		}

--- a/src/main/java/synapseawsconsolelogin/Auth.java
+++ b/src/main/java/synapseawsconsolelogin/Auth.java
@@ -930,8 +930,8 @@ public class Auth extends HttpServlet {
 		if (name.length()<1) {
 			throw new IllegalArgumentException("SSM parameter name cannot be empty.");
 		}
-		try {
-			DefaultCredentialsProvider.create().resolveCredentials();
+		try (DefaultCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create()) {
+			credentialsProvider.resolveCredentials();
 		} catch (SdkClientException e) {
 			return null;
 		}

--- a/src/test/java/synapseawsconsolelogin/AuthTest.java
+++ b/src/test/java/synapseawsconsolelogin/AuthTest.java
@@ -47,19 +47,17 @@ import org.sagebionetworks.repo.model.oauth.OAuthScope;
 import org.sagebionetworks.repo.model.oauth.OIDCClaimsRequestDetails;
 import org.scribe.model.Token;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
-import com.amazonaws.services.securitytoken.model.Credentials;
-import com.amazonaws.services.securitytoken.model.Tag;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
-import com.amazonaws.services.simplesystemsmanagement.model.ParameterType;
-import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+import software.amazon.awssdk.services.sts.model.Tag;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.ParameterType;
+import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.impl.DefaultClaims;
@@ -71,7 +69,7 @@ public class AuthTest {
 	private static final String TEST_PROPERTY_NAME = "testPropertyName";
 	
 	@Mock
-	private AWSSecurityTokenService mockStsClient;
+	private StsClient mockStsClient;
 	
 	@Mock
 	private TokenRetriever mockTokenRetriever;
@@ -147,18 +145,22 @@ public class AuthTest {
 
 		when(mockHttpResponse.getOutputStream()).thenReturn(mockOutputStream);
 		
-		AssumeRoleResult assumeRoleResult = new AssumeRoleResult();
-		
-		Credentials credentials = new Credentials();
-		credentials.setAccessKeyId("accessKeyId");
-		credentials.setSecretAccessKey("secretAccessKey");
-		credentials.setSessionToken("sessionToken");
 		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 		TimeZone tz = TimeZone.getTimeZone("UTC");
 		df.setTimeZone(tz);
-		credentials.setExpiration(df.parse(STS_EXPIRES_ON));
-		assumeRoleResult.setCredentials(credentials);
-		when(mockStsClient.assumeRole(any())).thenReturn(assumeRoleResult);
+		
+		Credentials credentials = Credentials.builder()
+				.accessKeyId("accessKeyId")
+				.secretAccessKey("secretAccessKey")
+				.sessionToken("sessionToken")
+				.expiration(df.parse(STS_EXPIRES_ON).toInstant())
+				.build();
+		
+		AssumeRoleResponse assumeRoleResponse = AssumeRoleResponse.builder()
+				.credentials(credentials)
+				.build();
+		
+		when(mockStsClient.assumeRole(any(AssumeRoleRequest.class))).thenReturn(assumeRoleResponse);
 		
 		IdAndAccessToken idAndAccessToken = new IdAndAccessToken(new Token(ID_TOKEN, ""), new Token(ACCESS_TOKEN, ""));
 		when(mockTokenRetriever.getTokens(anyString(), anyString())).thenReturn(idAndAccessToken);
@@ -231,13 +233,13 @@ public class AuthTest {
 	public void testGetSSMParameter() {
 		Assume.assumeTrue(System.getProperty("SKIP_AWS")==null);
 		// we only want to run this test if we can connect to AWS
-		AWSCredentials credentials = null;
+		AwsCredentials credentials = null;
 		try {
-			credentials = DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+			credentials = DefaultCredentialsProvider.create().resolveCredentials();
 		} catch (SdkClientException e) {
 			Assume.assumeNoException(e);
 		}
-		Assume.assumeNotNull(credentials, credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey());
+		Assume.assumeNotNull(credentials, credentials.accessKeyId(), credentials.secretAccessKey());
 		
 		String propertyName = UUID.randomUUID().toString();
 		String ssmKey = UUID.randomUUID().toString();
@@ -249,15 +251,14 @@ public class AuthTest {
 		System.setProperty(propertyName, "ssm::"+ssmKey);
 		
 		// now let's store the property in SSM
-		try {
-			AWSSimpleSystemsManagement ssmClient = AWSSimpleSystemsManagementClientBuilder.defaultClient();
-			
-			PutParameterRequest putParameterRequest = new PutParameterRequest();
-			putParameterRequest.setName(ssmKey);
-			putParameterRequest.setValue(propertyValue);
-			putParameterRequest.setType(ParameterType.SecureString);
+		try (SsmClient ssmClient = SsmClient.builder().build()) {
+			PutParameterRequest putParameterRequest = PutParameterRequest.builder()
+					.name(ssmKey)
+					.value(propertyValue)
+					.type(ParameterType.SECURE_STRING)
+					.build();
 			ssmClient.putParameter(putParameterRequest);
-		} catch (AmazonClientException e) {
+		} catch (SdkClientException e) {
 			// cannot continue with this integration test
 			return;
 		}
@@ -271,13 +272,13 @@ public class AuthTest {
 		Assume.assumeTrue(System.getProperty("SKIP_AWS")==null);
 
 		// we only want to run this test if we can connect to AWS
-		AWSCredentials credentials = null;
+		AwsCredentials credentials = null;
 		try {
-			credentials = DefaultAWSCredentialsProviderChain.getInstance().getCredentials();
+			credentials = DefaultCredentialsProvider.create().resolveCredentials();
 		} catch (SdkClientException e) {
 			Assume.assumeNoException(e);
 		}
-		Assume.assumeNotNull(credentials, credentials.getAWSAccessKeyId(), credentials.getAWSSecretKey());
+		Assume.assumeNotNull(credentials, credentials.accessKeyId(), credentials.secretAccessKey());
 
 		String propertyName = UUID.randomUUID().toString();
 		String ssmKey = UUID.randomUUID().toString();
@@ -295,10 +296,11 @@ public class AuthTest {
 	public void testGetConsoleLoginURL() throws Exception {
 		when(mockHttpGetExecutor.executeHttpGet(anyString(), eq((String)null))).thenReturn("{\"SigninToken\":\"token\"}");
 		
-		Credentials credentials = new Credentials();
-		credentials.setAccessKeyId("keyId");
-		credentials.setSecretAccessKey("keySecret");
-		credentials.setSessionToken("token");
+		Credentials credentials = Credentials.builder()
+				.accessKeyId("keyId")
+				.secretAccessKey("keySecret")
+				.sessionToken("token")
+				.build();
 		
 		// method under test
 		String actual = auth.getConsoleLoginURL(mockHttpRequest, credentials);
@@ -350,18 +352,18 @@ public class AuthTest {
 		// method under test
 		AssumeRoleRequest request = auth.createAssumeRoleRequest(claims, roleArn, selectedTeam);
 		
-		assertEquals(roleArn, request.getRoleArn());
-		assertEquals("1:aname", request.getRoleSessionName());
+		assertEquals(roleArn, request.roleArn());
+		assertEquals("1:aname", request.roleSessionName());
 		
-		assertEquals(4, request.getTags().size());
+		assertEquals(4, request.tags().size());
 
-		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-user_name").withValue("aname")));
-		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-userid").withValue("1")));
-		assertTrue(request.getTags().contains((new Tag()).withKey("synapse-team").withValue("10101")));
+		assertTrue(request.tags().contains(Tag.builder().key("synapse-user_name").value("aname").build()));
+		assertTrue(request.tags().contains(Tag.builder().key("synapse-userid").value("1").build()));
+		assertTrue(request.tags().contains(Tag.builder().key("synapse-team").value("10101").build()));
 		
 		boolean containsNonceTag = false;
-		for (Tag tag : request.getTags()) {
-			if (tag.getKey().equals("synapse-nonce") && StringUtils.isNotEmpty(tag.getValue())) {
+		for (Tag tag : request.tags()) {
+			if (tag.key().equals("synapse-nonce") && StringUtils.isNotEmpty(tag.value())) {
 				containsNonceTag = true;
 			}
 		}


### PR DESCRIPTION
using AWS Kiro to upgrade AWS Java SDK from version 1 to version 2

pom.xml changes:

Replaced com.amazonaws:aws-java-sdk:1.12.772 with AWS SDK v2 modular dependencies: 
software.amazon.awssdk:sts:2.29.16 (Security Token Service) software.amazon.awssdk:ssm:2.29.16 (Systems Manager) 

Code changes in Auth.java:

* Updated imports from com.amazonaws.* to software.amazon.awssdk.* 
* Changed AWSSecurityTokenService to StsClient with builder pattern Changed AWSSimpleSystemsManagement to SsmClient with builder pattern 
* Updated AssumeRoleResult to AssumeRoleResponse
* Migrated from setter methods to builder pattern for requests 
* Changed getter methods to accessor methods (e.g., getAccessKeyId() → accessKeyId()) 
* Updated credential provider from DefaultAWSCredentialsProviderChain to  DefaultCredentialsProvider 
* Changed Regions.fromName() to Region.of()
* Updated date handling for credentials expiration (Date → Instant) 

Test changes in AuthTest.java:

* Updated all AWS SDK imports to v2
* Migrated mock objects and test assertions to use v2 APIs Updated builder patterns for test data creation

